### PR TITLE
Add Minimum Supported Rust Version (1.34.2)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-2019", "ubuntu-16.04", "ubuntu-18.04", "macOS-latest"]
-        toolchain: ["stable", "beta", "nightly"]
+        toolchain: ["stable", "beta", "nightly", "1.34.2"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
         run: cargo build --all-targets --all-features --verbose
 
       - name: Perform unit testing and integration testing
-        run: cargo test --workspace --all-targets --all-features
+        run: cargo test --all-targets --all-features
 
       - name: Perform documentation tests
         run: cargo test --doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ byteorder = { version = "1.3.1", features = ["i128"] }
 [dev-dependencies]
 libflate = "0.1"
 mrt-rs = "1.1.0"
-pcap-file = "0.10.0"
-etherparse = "0.8.0"
+pcap-file = "1.1"
+etherparse = "0.9.0"
 twoway = "0.2.0"
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ In the table below one can see the status of each path attribute:
 |   40   |                 BGP Prefix-SID                |                   [RFC-ietf-idr-bgp-prefix-sid-27](http://www.iana.org/go/draft-ietf-idr-bgp-prefix-sid-27)                   | Not yet implemented |
 |   128  |                    ATTR_SET                   |                                           [RFC6368](http://www.iana.org/go/rfc6368)                                           |     Implemented     |
 
+# Minimum Supported Rust Version
+This crate's minimum supported `rustc` version is `1.34.2`.
+
 # Crate Features
 The default feature set includes encoding & decoding of BGP Messages with attributes listed above
 


### PR DESCRIPTION
`bgp-rs` builds and works fine with `rustc` 1.34.2, but cargo couldn't test because of dev-dependencies requiring a newer `rustc`. 

I went dependency diving and found that the issue was with `gimli`, a dependency of `error-chain` used in `pcap-file`. `pcap-file` moved to `thiserror` in a newer release, so updating the dev-dependency to post 1.0 fixes our cargo test issue and we can finally add `1.34.2` to the GitHub actions to enforce the MSRV 😃 

cc @TheBlueMatt