### PR TITLE
Detect Multiple Labels capability & ADD-PATH heuristics

### DIFF
--- a/src/open.rs
+++ b/src/open.rs
@@ -225,7 +225,7 @@ impl OpenCapability {
                     }
 
                     OpenCapability::MultipleLabels(set)
-                },
+                }
                 // 4_BYTE_ASN
                 65 => {
                     if cap_length != 4 {
@@ -478,7 +478,9 @@ impl Capabilities {
                         }
                         OpenCapability::MultipleLabels(multi_labels) => {
                             for (afi, safi, count) in multi_labels {
-                                capabilities.MULTIPLE_LABELS_SUPPORT.insert((afi, safi), count);
+                                capabilities
+                                    .MULTIPLE_LABELS_SUPPORT
+                                    .insert((afi, safi), count);
                             }
                         }
                         OpenCapability::FourByteASN(_) => {

--- a/src/update/attributes.rs
+++ b/src/update/attributes.rs
@@ -855,6 +855,7 @@ impl Segment {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use maplit::hashset;
 
     // Macro to make building a new `Prefix` easier
     //
@@ -976,11 +977,9 @@ mod tests {
                     ],
                 }),
                 Some(Capabilities::from_parameters(vec![
-                    OpenParameter::Capabilities(vec![OpenCapability::AddPath(vec![(
-                        AFI::IPV4,
-                        SAFI::Unicast,
-                        AddPathDirection::SendReceivePaths,
-                    )])]),
+                    OpenParameter::Capabilities(vec![OpenCapability::AddPath(hashset! {
+                        (AFI::IPV4, SAFI::Unicast, AddPathDirection::SendReceivePaths)
+                    })]),
                 ])),
             ),
             (

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -64,7 +64,7 @@ impl Update {
         let mut withdrawn_routes: Vec<NLRIEncoding> = Vec::with_capacity(0);
         let mut cursor = Cursor::new(buffer);
 
-        if capabilities.EXTENDED_PATH_NLRI_SUPPORT {
+        if util::detect_add_path_prefix(&mut cursor, 255)? {
             while cursor.position() < withdraw_len as u64 {
                 let path_id = cursor.read_u32::<BigEndian>()?;
                 let prefix = Prefix::parse(&mut cursor, AFI::IPV4)?;

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -64,14 +64,12 @@ impl Update {
         let mut withdrawn_routes: Vec<NLRIEncoding> = Vec::with_capacity(0);
         let mut cursor = Cursor::new(buffer);
 
-        if util::detect_add_path_prefix(&mut cursor, 255)? {
-            while cursor.position() < withdraw_len as u64 {
+        while cursor.position() < withdraw_len as u64 {
+            if util::detect_add_path_prefix(&mut cursor, 255)? {
                 let path_id = cursor.read_u32::<BigEndian>()?;
                 let prefix = Prefix::parse(&mut cursor, AFI::IPV4)?;
                 withdrawn_routes.push(NLRIEncoding::IP_WITH_PATH_ID((prefix, path_id)));
-            }
-        } else {
-            while cursor.position() < withdraw_len as u64 {
+            } else {
                 withdrawn_routes.push(NLRIEncoding::IP(Prefix::parse(&mut cursor, AFI::IPV4)?));
             }
         }

--- a/src/update/nlri.rs
+++ b/src/update/nlri.rs
@@ -172,14 +172,12 @@ fn parse_nlri(
             }
             // DEFAULT
             _ => {
-                if util::detect_add_path_prefix(buf, 255)? {
-                    while buf.position() < u64::from(size) {
+                while buf.position() < u64::from(size) {
+                    if util::detect_add_path_prefix(buf, 255)? {
                         let path_id = buf.read_u32::<BigEndian>()?;
                         let prefix = Prefix::parse(buf, afi)?;
                         nlri.push(NLRIEncoding::IP_WITH_PATH_ID((prefix, path_id)));
-                    }
-                } else {
-                    while buf.position() < u64::from(size) {
+                    } else {
                         let prefix = Prefix::parse(buf, afi)?;
                         nlri.push(NLRIEncoding::IP(prefix));
                     }

--- a/src/update/nlri.rs
+++ b/src/update/nlri.rs
@@ -93,7 +93,7 @@ impl MPUnreachNLRI {
         stream: &mut impl Read,
         length: u16,
         capabilities: &Capabilities,
-    ) -> io::Result<MPUnreachNLRI> {
+    ) -> Result<MPUnreachNLRI, Error> {
         let afi = AFI::try_from(stream.read_u16::<BigEndian>()?)?;
         let safi = SAFI::try_from(stream.read_u8()?)?;
 
@@ -147,7 +147,7 @@ fn parse_l2vpn(buf: &mut impl Read) -> io::Result<Vec<NLRIEncoding>> {
 fn parse_nlri(
     afi: AFI,
     safi: SAFI,
-    capabilities: &Capabilities,
+    _capabilities: &Capabilities,
     buf: &mut Cursor<Vec<u8>>,
     size: u16,
 ) -> io::Result<Vec<NLRIEncoding>> {
@@ -172,7 +172,7 @@ fn parse_nlri(
             }
             // DEFAULT
             _ => {
-                if capabilities.EXTENDED_PATH_NLRI_SUPPORT {
+                if util::detect_add_path_prefix(buf, 255)? {
                     while buf.position() < u64::from(size) {
                         let path_id = buf.read_u32::<BigEndian>()?;
                         let prefix = Prefix::parse(buf, afi)?;

--- a/src/update/nlri.rs
+++ b/src/update/nlri.rs
@@ -93,7 +93,7 @@ impl MPUnreachNLRI {
         stream: &mut impl Read,
         length: u16,
         capabilities: &Capabilities,
-    ) -> Result<MPUnreachNLRI, Error> {
+    ) -> io::Result<MPUnreachNLRI> {
         let afi = AFI::try_from(stream.read_u16::<BigEndian>()?)?;
         let safi = SAFI::try_from(stream.read_u8()?)?;
 

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -1,4 +1,5 @@
 use bgp_rs::*;
+use maplit::hashset;
 use std::net::Ipv4Addr;
 
 #[test]
@@ -204,11 +205,9 @@ fn test_update_extended_path_support() {
         record_type: 2,
     };
     let capabilities = Capabilities::from_parameters(vec![OpenParameter::Capabilities(vec![
-        OpenCapability::AddPath(vec![(
-            AFI::IPV4,
-            SAFI::Unicast,
-            AddPathDirection::SendReceivePaths,
-        )]),
+        OpenCapability::AddPath(hashset! {
+            (AFI::IPV4, SAFI::Unicast, AddPathDirection::SendReceivePaths)
+        }),
     ])]);
     let update = Update::parse(&header, &mut buf, &capabilities).unwrap();
     assert_eq!(update.withdrawn_routes.len(), 2);

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -60,10 +60,11 @@ fn test_encode_open() {
             0xfd, 0xe8, // ASN
             0, 0x3c, // Hold Timer
             0x01, 0x01, 0x01, 0x01, // Identifier
-            20, // Parameter Length
-            0x02, 0x06, 0x01, 0x04, 0x00, 0x02, 0x00, 0x01, // IPv6 - Unicast
-            0x02, 0x06, 0x41, 0x04, 0x00, 0x00, 0xfd, 0xe8, // 4-byte ASN
-            0x02, 0x02, 0x02, 0x00 // Route Refresh
+            16, // Length of Parameters
+            0x02, 14, // Parameter type (Capability) and length
+            0x01, 0x04, 0x00, 0x02, 0x00, 0x01, // IPv6 - Unicast
+            0x41, 0x04, 0x00, 0x00, 0xfd, 0xe8, // 4-byte ASN
+            0x02, 0x00 // Route Refresh
         ]
     );
 
@@ -71,7 +72,7 @@ fn test_encode_open() {
     #[rustfmt::skip]
     assert_eq!(
         message_data[16..19],
-        [0, 49, 1][..],
+        [0, 45, 1][..],
     );
 }
 


### PR DESCRIPTION
Adds detection (not yet NLRI parsing) for multiple labels capability ([RFC 8277](https://tools.ietf.org/html/rfc8277)) and uses heuristics everywhere to detect whether there's a path ID on a given NLRI.

My use case here so far is decoding BMP RouteMonitoring messages which are post-state machine and relying on negotiated capabilities there is a bit hit-and-miss. I realise this probably isn't _really_ the implementation wanted in a crate thats clearly working towards being usable as a BGP speaker so this PR is just to start a discussion about how best to support both use cases